### PR TITLE
Add support for haxe nightlies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        haxe: [4.2.5, 3.4.7]
+        haxe: [4.2.5, 3.4.7, latest]
       fail-fast: true
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: 'Version Spec of the version to use. Example: 4.2.5'
     required: true
     default: '4.2.5'
-  haxe-nightly:
-    description: 'Use haxe nightlies instead of releases.'
-    required: false
-    default: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Version Spec of the version to use. Example: 4.2.5'
     required: true
     default: '4.2.5'
+  haxe-nightly:
+    description: 'Use haxe nightlies instead of releases.'
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2856,7 +2856,7 @@ function main() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const inputVersion = core.getInput('haxe-version');
-            const nightly = core.getBooleanInput('haxe-nightly');
+            const nightly = /^(\d{4}-\d{2}-\d{2}_[\w\.-]+_\w+)|latest$/.test(inputVersion);
             const version = nightly ? inputVersion : semver.valid(semver.clean(inputVersion));
             if (version) {
                 yield setup_1.setup(version, nightly);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -116,11 +116,16 @@ export class NekoAsset extends Asset {
 // * NOTE https://github.com/HaxeFoundation/haxe/releases/download/4.0.5/haxe-4.0.5-linux64.tar.gz
 // * NOTE https://github.com/HaxeFoundation/haxe/releases/download/3.4.7/haxe-3.4.7-win64.zip
 export class HaxeAsset extends Asset {
-  constructor(version: string, env = new Env()) {
+  nightly = false;
+
+  constructor(version: string, nightly: boolean, env = new Env()) {
     super('haxe', version, env);
+    this.nightly = nightly;
   }
 
   get downloadUrl() {
+    if (this.nightly)
+      return `https://build.haxe.org/builds/haxe/${this.nightlyTarget}/${this.fileNameWithoutExt}${this.fileExt}`;
     return super.makeDownloadUrl(
       `/haxe/releases/download/${this.version}/${this.fileNameWithoutExt}${this.fileExt}`
     );
@@ -134,7 +139,22 @@ export class HaxeAsset extends Asset {
     }
   }
 
+  get nightlyTarget() {
+    const plat = this.env.platform;
+    switch (plat) {
+      case 'osx':
+        return 'mac';
+      case 'linux':
+        return 'linux64';
+      case 'win':
+        return 'windows64';
+      default:
+        throw new Error(`${plat} not supported`);
+    }
+  }
+
   get fileNameWithoutExt() {
+    if (this.nightly) return `haxe_${this.version}`;
     return `haxe-${this.version}-${this.target}`;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { setup } from './setup';
 async function main(): Promise<void> {
   try {
     const inputVersion = core.getInput('haxe-version');
-    const nightly = core.getBooleanInput('haxe-nightly');
+    const nightly = /^(\d{4}-\d{2}-\d{2}_[\w\.-]+_\w+)|latest$/.test(inputVersion);
     const version = nightly ? inputVersion : semver.valid(semver.clean(inputVersion));
     if (version) {
       await setup(version, nightly);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,10 @@ import { setup } from './setup';
 async function main(): Promise<void> {
   try {
     const inputVersion = core.getInput('haxe-version');
-    const version = semver.valid(semver.clean(inputVersion));
+    const nightly = core.getBooleanInput('haxe-nightly');
+    const version = nightly ? inputVersion : semver.valid(semver.clean(inputVersion));
     if (version) {
-      await setup(version);
+      await setup(version, nightly);
     }
   } catch (error) {
     core.setFailed(error.message);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,14 +10,14 @@ import { NekoAsset, HaxeAsset, Env } from './asset';
 
 const env = new Env();
 
-export async function setup(version: string) {
+export async function setup(version: string, nightly: boolean) {
   const neko = new NekoAsset('2.3.0'); // haxelib requires Neko
   const nekoPath = await neko.setup();
   core.addPath(nekoPath);
   core.exportVariable('NEKOPATH', nekoPath);
   core.exportVariable('LD_LIBRARY_PATH', `${nekoPath}:$LD_LIBRARY_PATH`);
 
-  const haxe = new HaxeAsset(version);
+  const haxe = new HaxeAsset(version, nightly);
   const haxePath = await haxe.setup();
   core.addPath(haxePath);
   core.exportVariable('HAXE_STD_PATH', path.join(haxePath, 'std'));


### PR DESCRIPTION
Add support for haxe nightlies from https://build.haxe.org/builds/haxe/ when setting `haxe-version` to `latest` or a specific nightly build, for example `"2023-01-12_development_7de5898"` (basically anything between `haxe_` and extension in https://build.haxe.org/builds/haxe/linux64/).

Example use:

```yml
jobs:
  build:
    strategy:
      matrix:
        os: [ubuntu-latest, macos-latest, windows-latest]
        haxe: [4.2.5, latest, "2023-01-23_development_c655aa5"]
    runs-on: ${{ matrix.os }}
    steps:
      # use krdlab/setup-haxe@v1 when merged
      - uses: kLabz/setup-haxe@6c750ad16187ca792f2cdddfd8c57177205f4ecd
        with:
          haxe-version: ${{ matrix.haxe }}

      - run: haxe -version

      # ...
```