### PR TITLE
Fix error when invoking setup-haxe twice in a workflow on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,14 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v3 #https://github.com/actions/checkout
 
-    - uses: ./
+    - name: Install Haxe ${{ matrix.haxe }}
+      uses: ./
+      with:
+        haxe-version: ${{ matrix.haxe }}
+
+    # install twice to verify re-installation works
+    - name: Install Haxe ${{ matrix.haxe }} 
+      uses: ./
       with:
         haxe-version: ${{ matrix.haxe }}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1069,6 +1069,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = __importStar(__webpack_require__(622));
+const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
 const tc = __importStar(__webpack_require__(533));
 const core = __importStar(__webpack_require__(470));
@@ -1101,6 +1102,9 @@ class Asset {
         });
     }
     extract(file, dest, ext) {
+        if (fs.existsSync(dest)) {
+            fs.rmdirSync(dest, { recursive: true });
+        }
         switch (ext) {
             case '.tar.gz':
                 return tc.extractTar(file, dest);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT
 
 import * as path from 'path';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as tc from '@actions/tool-cache';
 import * as core from '@actions/core';
@@ -35,6 +36,9 @@ abstract class Asset {
   }
 
   private extract(file: string, dest: string, ext: AssetFileExt) {
+    if (fs.existsSync(dest)) {
+      fs.rmdirSync(dest, { recursive: true });
+    }
     switch (ext) {
       case '.tar.gz':
         return tc.extractTar(file, dest);


### PR DESCRIPTION
This PR fixes an issue when using setup-haxe twice in a workflow. On Windows the following error is thrown:

```powershell
C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.FileSystem } catch { } ;
[System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\014fcafc-26f7-4d2c-8088-a3bceb1c1326', 'haxe_latest')"
Exception calling "ExtractToDirectory" with "2" argument(s): "The file 'D:\a\sshtest\sshtest\haxe_latest\haxe_20230209140625_9ce3d16\CHANGES.txt' already exists."
At line:1 char:111
+ ... catch { } ; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [],
ParentContainsErrorRecordException
    + FullyQualifiedErrorId : IOException

Error: The process 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' failed with exit code 1
```