### PR TITLE
Fix failing ci checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
         - latest
         - 4.3.4
         - 3.4.7
+        include:
+        - lib_hxml: lib.hxml
+        - haxe: 3.4.7
+          lib_hxml: lib_haxe3.hxml
 
     steps:
 
@@ -53,11 +57,11 @@ jobs:
       uses: ./
       with:
         haxe-version: ${{ matrix.haxe }}
-        cache-dependency-path: 'test-workflow/lib.hxml'
+        cache-dependency-path: 'test-workflow/${{ matrix.lib_hxml }}'
 
     - run: haxe -version
 
-    - run: haxelib install test-workflow/lib.hxml --always
+    - run: haxelib install test-workflow/${{ matrix.lib_hxml }} --always
 
     - name: Compile test code
       run: |

--- a/test-workflow/lib_haxe3.hxml
+++ b/test-workflow/lib_haxe3.hxml
@@ -1,0 +1,1 @@
+-lib hxnodejs:12.1.0


### PR DESCRIPTION
hxnodejs had a recent [update that broke haxe 3 support](https://github.com/HaxeFoundation/hxnodejs/commit/504066dc1ba5ad543afa5f6c3ea019f06136a82b), so haxe 3 has to stick to an old version.