### PR TITLE
Haxe version and neko url update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         - windows-latest
         haxe:
         - latest
-        - 4.3.4
+        - 4.3.5
         - 3.4.7
         include:
         - lib_hxml: lib.hxml

--- a/dist/index.js
+++ b/dist/index.js
@@ -149,12 +149,12 @@ class Asset {
         return found ? toolRoot : null;
     }
 }
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.3.0-rc.1-linux64.tar.gz
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.4.0-rc.1-osx-universal.tar.gz
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.3.0-rc.1-win64.zip
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-linux64.tar.gz
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-osx-universal.tar.gz
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 class NekoAsset extends Asset {
     static resolveFromHaxeVersion(version) {
-        const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0-rc.1'; // Haxe 3 only supports neko 2.1
+        const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0'; // Haxe 3 only supports neko 2.1
         return new NekoAsset(nekoVer);
     }
     constructor(version, env = new Env()) {

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -100,12 +100,12 @@ abstract class Asset {
   }
 }
 
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.3.0-rc.1-linux64.tar.gz
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.4.0-rc.1-osx-universal.tar.gz
-// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0-rc-1/neko-2.3.0-rc.1-win64.zip
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-linux64.tar.gz
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-osx-universal.tar.gz
+// * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 export class NekoAsset extends Asset {
   static resolveFromHaxeVersion(version: string) {
-    const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0-rc.1'; // Haxe 3 only supports neko 2.1
+    const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0'; // Haxe 3 only supports neko 2.1
     return new NekoAsset(nekoVer);
   }
 


### PR DESCRIPTION
Very small follow up from the previous PRs. Neko 2.4 is no longer RC so I've updated the urls and haxe 4.3.5 is out so I've updated the CI to use that.