### PR TITLE
Use neko 2.3.0 for haxe installs pre-4.3

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -154,7 +154,9 @@ class Asset {
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 class NekoAsset extends Asset {
     static resolveFromHaxeVersion(version) {
-        const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0'; // Haxe 3 only supports neko 2.1
+        const nekoVer = version.startsWith('3.') ? '2.1.0' // Haxe 3 only supports neko 2.1
+            : (version.startsWith('4.') && version < '4.3.' ? '2.3.0' // Haxe 4.0..4.2 has issues with mbedtls 3 in neko 2.4
+                : '2.4.0');
         return new NekoAsset(nekoVer);
     }
     constructor(version, env = new Env()) {

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -105,7 +105,9 @@ abstract class Asset {
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 export class NekoAsset extends Asset {
   static resolveFromHaxeVersion(version: string) {
-    const nekoVer = version.startsWith('3.') ? '2.1.0' : '2.4.0'; // Haxe 3 only supports neko 2.1
+    const nekoVer = version.startsWith('3.') ? '2.1.0' // Haxe 3 only supports neko 2.1
+      : (version.startsWith('4.') && version < '4.3.' ? '2.3.0' // Haxe 4.0..4.2 has issues with mbedtls 3 in neko 2.4
+        : '2.4.0');
     return new NekoAsset(nekoVer);
   }
 


### PR DESCRIPTION
Neko 2.4.0 upgraded to mbedtls 3, which for some reason triggers [a bug in the haxe std](https://github.com/HaxeFoundation/haxe/pull/10751) that used to occur in haxe 4 versions prior to 4.3.0. Since each haxe install comes with a haxelib built with that compiler version, it means that all haxelib builds from 4.0..4.2.5 are affected by this issue, and lead to this error when attempting to perform any request:
```
$ haxelib info dox --debug
Called from ? line 1
Called from haxelib/client/Util.hx line 9
Called from haxelib/client/Main.hx line 1803
Called from haxelib/client/Util.hx line 9
Called from haxelib/client/Main.hx line 498
Called from haxelib/client/Main.hx line 550
Called from haxelib/client/Main.hx line 240
Uncaught exception - Failed with error: Eof
```

By keeping to neko 2.3.0 for haxe versions pre 4.3.0, we avoid this bug being triggered which allows the shipped haxelib binaries to work as expected.

See also: https://github.com/HaxeFoundation/neko/issues/312