### PR TITLE
Use newer neko version for haxe 3

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -153,22 +153,26 @@ class Asset {
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-osx-universal.tar.gz
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 class NekoAsset extends Asset {
+    force32;
     static resolveFromHaxeVersion(version) {
-        const nekoVer = version.startsWith('3.') ? '2.1.0' // Haxe 3 only supports neko 2.1
-            : (version.startsWith('4.') && version < '4.3.' ? '2.3.0' // Haxe 4.0..4.2 has issues with mbedtls 3 in neko 2.4
-                : '2.4.0');
-        return new NekoAsset(nekoVer);
+        // Haxe older than 4.3 has issues with mbedtls 3 in neko 2.4
+        const nekoVer = version.startsWith('3.') || (version.startsWith('4.') && version < '4.3.') ? '2.3.0'
+            : '2.4.0';
+        const env = new Env();
+        // Haxe 3 on windows has 32 bit haxelib, which requires 32 bit neko
+        const force32 = version.startsWith('3.') && env.platform === 'win';
+        return new NekoAsset(nekoVer, force32, env);
     }
-    constructor(version, env = new Env()) {
+    constructor(version, force32, env = new Env()) {
         super('neko', version, env);
+        this.force32 = force32;
     }
     get downloadUrl() {
         const tag = `v${this.version.replace(/\./g, '-')}`;
         return super.makeDownloadUrl(`/neko/releases/download/${tag}/${this.fileNameWithoutExt}${this.fileExt}`);
     }
     get target() {
-        // No 64bit version of neko 2.1 available for windows
-        if (this.env.platform === 'win' && this.version.startsWith('2.1')) {
+        if (this.force32) {
             return this.env.platform;
         }
         if (this.env.platform === 'osx' && this.version.startsWith('2.4')) {


### PR DESCRIPTION
The original problem described in #7 was that haxe 3 ships 32 bit haxelib on windows, which therefore requires 32 bit neko. This means it should be possible to install a newer version of neko, as long as it is still a 32 bit build.

This avoids other compatibility issues when running certain neko scripts, e.g.: `Uncaught exception - load.c(357) : Primitive not found : std@date_utc_format(2)`