### PR TITLE
refactor: consolidate platform/arch/nightly resolution into a pure resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 
 This action sets up a Haxe environment for use in your workflows.
 
+## Supported combinations
+
+| Runner OS / Arch | `haxe-version` |
+| --- | --- |
+| `ubuntu-latest` (x64) | stable (e.g. `4.3.7`, `3.4.7`) / `latest` (nightly) |
+| `macos-latest` (Intel / Apple Silicon) | stable / `latest` |
+| `windows-latest` (x64) | stable / `latest` |
+| `ubuntu-24.04-arm` (Linux ARM64) | `latest` (nightly) only |
+
+Notes:
+
+- Linux ARM64 only works with `haxe-version: latest`. HaxeFoundation does not publish stable Haxe ARM64 archives, and Neko 2.3.x (used by Haxe 3.x / 4.0–4.2) has no ARM64 binary. Stable Haxe / Neko 2.3 on Linux ARM64 will fail with an explicit error.
+- Windows ARM64 is not supported (no upstream Haxe / Neko archives).
+
 ## Usage
 
 See [action.yml](action.yml) and [.github/workflows/](.github/workflows/).
@@ -37,7 +51,8 @@ jobs:
       - run: haxe -version
 ```
 
-Caching global packages data:
+## Caching global packages data
+
 ```yaml
 jobs:
   build:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -34987,9 +34987,6 @@ module.exports = {
 "use strict";
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
 __nccwpck_require__.r(__webpack_exports__);
-/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   "run": () => (/* binding */ run)
-/* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2186);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _haxelib__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(8477);

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,6 +50,8 @@ __nccwpck_require__.d(__webpack_exports__, {
   "c": () => (/* binding */ setup)
 });
 
+// EXTERNAL MODULE: external "node:os"
+var external_node_os_ = __nccwpck_require__(70612);
 ;// CONCATENATED MODULE: external "node:path"
 const external_node_path_namespaceObject = require("node:path");
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
@@ -60,8 +62,6 @@ var exec = __nccwpck_require__(71514);
 var external_node_crypto_ = __nccwpck_require__(6005);
 // EXTERNAL MODULE: external "node:fs"
 var external_node_fs_ = __nccwpck_require__(87561);
-// EXTERNAL MODULE: external "node:os"
-var external_node_os_ = __nccwpck_require__(70612);
 // EXTERNAL MODULE: external "node:process"
 var external_node_process_ = __nccwpck_require__(97742);
 // EXTERNAL MODULE: ./node_modules/@actions/tool-cache/lib/tool-cache.js
@@ -79,14 +79,117 @@ var tool_cache = __nccwpck_require__(27784);
 
 
 
+function resolveTarget(input) {
+    const { tool, platform, arch } = input;
+    if (platform === 'win32' && arch === 'arm64') {
+        return {
+            kind: 'unsupported',
+            reason: 'Windows ARM64 is not supported (no upstream Haxe/Neko archives).',
+        };
+    }
+    if (platform !== 'darwin' && platform !== 'linux' && platform !== 'win32') {
+        return { kind: 'unsupported', reason: `${platform} is not supported.` };
+    }
+    if (arch !== 'x64' && arch !== 'arm64') {
+        return { kind: 'unsupported', reason: `${arch} is not supported.` };
+    }
+    return tool === 'haxe'
+        ? resolveHaxe({ version: input.version, platform, arch, nightly: input.nightly })
+        : resolveNeko({
+            version: input.version,
+            platform,
+            arch,
+            nightly: input.nightly,
+            force32: input.force32,
+        });
+}
+function resolveHaxe(input) {
+    const { version, platform, arch, nightly } = input;
+    if (nightly) {
+        switch (platform) {
+            case 'darwin': {
+                return { kind: 'nightly', cachePlatform: 'osx', nightlyPathSegment: 'mac' };
+            }
+            case 'linux': {
+                return arch === 'arm64'
+                    ? { kind: 'nightly', cachePlatform: 'linux-arm64', nightlyPathSegment: 'linux-arm64' }
+                    : { kind: 'nightly', cachePlatform: 'linux64', nightlyPathSegment: 'linux64' };
+            }
+            case 'win32': {
+                return { kind: 'nightly', cachePlatform: 'win64', nightlyPathSegment: 'windows64' };
+            }
+        }
+    }
+    switch (platform) {
+        case 'darwin': {
+            return { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx' };
+        }
+        case 'linux': {
+            if (arch === 'arm64') {
+                return {
+                    kind: 'unsupported',
+                    reason: "Stable Haxe does not publish Linux ARM64 archives upstream; use 'haxe-version: latest'.",
+                };
+            }
+            return { kind: 'stable', cachePlatform: 'linux64', archiveTarget: 'linux64' };
+        }
+        case 'win32': {
+            if (version.startsWith('3.')) {
+                return { kind: 'stable', cachePlatform: 'win', archiveTarget: 'win' };
+            }
+            return { kind: 'stable', cachePlatform: 'win64', archiveTarget: 'win64' };
+        }
+    }
+}
+function resolveNeko(input) {
+    const { version, platform, arch, nightly, force32 } = input;
+    if (nightly) {
+        switch (platform) {
+            case 'darwin': {
+                return { kind: 'nightly', cachePlatform: 'osx', nightlyPathSegment: 'mac-universal' };
+            }
+            case 'linux': {
+                return arch === 'arm64'
+                    ? { kind: 'nightly', cachePlatform: 'linux-arm64', nightlyPathSegment: 'linux-arm64' }
+                    : { kind: 'nightly', cachePlatform: 'linux64', nightlyPathSegment: 'linux64' };
+            }
+            case 'win32': {
+                return { kind: 'nightly', cachePlatform: 'win64', nightlyPathSegment: 'windows64' };
+            }
+        }
+    }
+    switch (platform) {
+        case 'darwin': {
+            return version.startsWith('2.4')
+                ? { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx-universal' }
+                : { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx64' };
+        }
+        case 'linux': {
+            if (arch === 'arm64') {
+                if (version.startsWith('2.3')) {
+                    return {
+                        kind: 'unsupported',
+                        reason: "Neko 2.3.x has no Linux ARM64 binary; requires Neko 2.4+ (use Haxe 4.3+ or 'latest').",
+                    };
+                }
+                return { kind: 'stable', cachePlatform: 'linux-arm64', archiveTarget: 'linux-arm64' };
+            }
+            return { kind: 'stable', cachePlatform: 'linux64', archiveTarget: 'linux64' };
+        }
+        case 'win32': {
+            if (force32) {
+                return { kind: 'stable', cachePlatform: 'win', archiveTarget: 'win' };
+            }
+            return { kind: 'stable', cachePlatform: 'win64', archiveTarget: 'win64' };
+        }
+    }
+}
 class Asset {
     name;
     version;
-    env;
-    constructor(name, version, env) {
+    constructor(name, version) {
         this.name = name;
         this.version = version;
-        this.env = env;
     }
     async setup() {
         const toolPath = tool_cache.find(this.name, this.version);
@@ -99,14 +202,26 @@ class Asset {
         return `https://github.com/HaxeFoundation${path}`;
     }
     get fileExt() {
-        switch (this.env.platform) {
-            case 'win': {
-                return '.zip';
-            }
-            default: {
-                return '.tar.gz';
-            }
+        return external_node_os_.platform() === 'win32' ? '.zip' : '.tar.gz';
+    }
+    resolve(tool, force32 = false) {
+        return resolveTarget({
+            tool,
+            version: this.version,
+            platform: external_node_os_.platform(),
+            arch: external_node_os_.arch(),
+            nightly: this.isNightly,
+            force32,
+        });
+    }
+    get isNightly() {
+        return false;
+    }
+    requireSupported(resolution) {
+        if (resolution.kind === 'unsupported') {
+            throw new Error(resolution.reason);
         }
+        return resolution;
     }
     async download() {
         const downloadPath = await this.downloadWithCurl(this.downloadUrl);
@@ -188,63 +303,44 @@ class Asset {
 class NekoAsset extends Asset {
     force32;
     static resolveFromHaxeVersion(version, nightly) {
-        const env = new Env();
         if (nightly) {
-            return new NekoAsset('latest', true, false, env);
+            return new NekoAsset('latest', true, false);
         }
         // Haxe older than 4.3 has issues with mbedtls 3 in neko 2.4
         const nekoVer = version.startsWith('3.') || (version.startsWith('4.') && version < '4.3.') ? '2.3.0' : '2.4.0';
         // Haxe 3 on windows has 32 bit haxelib, which requires 32 bit neko
-        const force32 = version.startsWith('3.') && env.platform === 'win';
-        return new NekoAsset(nekoVer, false, force32, env);
+        const force32 = version.startsWith('3.') && external_node_os_.platform() === 'win32';
+        return new NekoAsset(nekoVer, false, force32);
     }
     nightly = false;
-    constructor(version, nightly, force32, env = new Env()) {
-        super('neko', version, env);
+    constructor(version, nightly, force32) {
+        super('neko', version);
         this.force32 = force32;
         this.nightly = nightly;
     }
+    get cachePlatform() {
+        return this.requireSupported(this.resolve('neko', this.force32)).cachePlatform;
+    }
     get downloadUrl() {
-        if (this.nightly) {
-            return `https://build.haxe.org/builds/neko/${this.nightlyTarget}/neko_${this.version}${this.fileExt}`;
+        const resolution = this.requireSupported(this.resolve('neko', this.force32));
+        if (resolution.kind === 'nightly') {
+            return `https://build.haxe.org/builds/neko/${resolution.nightlyPathSegment}/${this.fileNameWithoutExt}${this.fileExt}`;
         }
         const tag = `v${this.version.replace(/\./g, '-')}`;
         return super.makeDownloadUrl(`/neko/releases/download/${tag}/${this.fileNameWithoutExt}${this.fileExt}`);
     }
-    get target() {
-        if (this.force32) {
-            return this.env.platform;
-        }
-        if (this.env.platform === 'osx' && this.version.startsWith('2.4')) {
-            return 'osx-universal';
-        }
-        if (this.env.platform === 'linux' && this.env.arch === 'arm64') {
-            return 'linux-arm64';
-        }
-        return `${this.env.platform}${this.env.arch}`;
-    }
-    get nightlyTarget() {
-        const plat = this.env.platform;
-        switch (plat) {
-            case 'osx': {
-                return 'mac-universal';
-            }
-            case 'linux': {
-                return 'linux64';
-            }
-            case 'win': {
-                return 'windows64';
-            }
-            default: {
-                throw new Error(`${plat} not supported`);
-            }
-        }
-    }
     get fileNameWithoutExt() {
-        return `neko-${this.version}-${this.target}`;
+        const resolution = this.requireSupported(this.resolve('neko', this.force32));
+        if (resolution.kind === 'nightly') {
+            return `neko_${this.version}`;
+        }
+        return `neko-${this.version}-${resolution.archiveTarget}`;
     }
     get isDirectoryNested() {
         return true;
+    }
+    get isNightly() {
+        return this.nightly;
     }
 }
 // * NOTE https://github.com/HaxeFoundation/haxe/releases/download/4.0.5/haxe-4.0.5-linux64.tar.gz
@@ -252,80 +348,32 @@ class NekoAsset extends Asset {
 // * NOTE https://build.haxe.org/builds/haxe/mac/haxe_latest.tar.gz
 class HaxeAsset extends Asset {
     nightly = false;
-    constructor(version, nightly, env = new Env()) {
-        super('haxe', version, env);
+    constructor(version, nightly) {
+        super('haxe', version);
         this.nightly = nightly;
     }
+    get cachePlatform() {
+        return this.requireSupported(this.resolve('haxe')).cachePlatform;
+    }
     get downloadUrl() {
-        if (this.nightly) {
-            return `https://build.haxe.org/builds/haxe/${this.nightlyTarget}/${this.fileNameWithoutExt}${this.fileExt}`;
+        const resolution = this.requireSupported(this.resolve('haxe'));
+        if (resolution.kind === 'nightly') {
+            return `https://build.haxe.org/builds/haxe/${resolution.nightlyPathSegment}/${this.fileNameWithoutExt}${this.fileExt}`;
         }
         return super.makeDownloadUrl(`/haxe/releases/download/${this.version}/${this.fileNameWithoutExt}${this.fileExt}`);
     }
-    get target() {
-        if (this.env.platform === 'osx') {
-            return this.env.platform;
-        }
-        // No 64bit version of neko 2.1 available for windows, thus we can also only use 32bit version of Haxe 3
-        if (this.env.platform === 'win' && this.version.startsWith('3.')) {
-            return this.env.platform;
-        }
-        return `${this.env.platform}${this.env.arch}`;
-    }
-    get nightlyTarget() {
-        const plat = this.env.platform;
-        switch (plat) {
-            case 'osx': {
-                return 'mac';
-            }
-            case 'linux': {
-                return this.env.arch === 'arm64' ? 'linux-arm64' : 'linux64';
-            }
-            case 'win': {
-                return 'windows64';
-            }
-            default: {
-                throw new Error(`${plat} not supported`);
-            }
-        }
-    }
     get fileNameWithoutExt() {
-        if (this.nightly) {
+        const resolution = this.requireSupported(this.resolve('haxe'));
+        if (resolution.kind === 'nightly') {
             return `haxe_${this.version}`;
         }
-        return `haxe-${this.version}-${this.target}`;
+        return `haxe-${this.version}-${resolution.archiveTarget}`;
     }
     get isDirectoryNested() {
         return true;
     }
-}
-class Env {
-    get platform() {
-        const plat = external_node_os_.platform();
-        switch (plat) {
-            case 'linux': {
-                return 'linux';
-            }
-            case 'win32': {
-                return 'win';
-            }
-            case 'darwin': {
-                return 'osx';
-            }
-            default: {
-                throw new Error(`${plat} not supported`);
-            }
-        }
-    }
-    get arch() {
-        const arch = external_node_os_.arch();
-        if (arch === 'x64') {
-            return '64';
-        }
-        if (arch === 'arm64') {
-            return this.platform === 'osx' ? '64' : 'arm64';
-        }
-        throw new Error(`${arch} not supported`);
+    get isNightly() {
+        return this.nightly;
     }
 }
 
@@ -391,18 +439,21 @@ async function saveHaxelib() {
 
 
 
-const env = new Env();
+
 async function setup(version, nightly, cacheDependencyPath) {
+    const haxe = new HaxeAsset(version, nightly);
+    // Preflight: fail fast on unsupported combinations (e.g. stable Haxe + Linux ARM64)
+    // before downloading Neko. cachePlatform throws when the resolver returns 'unsupported'.
+    const haxeCachePlatform = haxe.cachePlatform;
     const neko = NekoAsset.resolveFromHaxeVersion(version, nightly); // Haxelib requires Neko
     const nekoPath = await neko.setup();
     lib_core.addPath(nekoPath);
     lib_core.exportVariable('NEKOPATH', nekoPath);
     lib_core.exportVariable('LD_LIBRARY_PATH', `${nekoPath}:$LD_LIBRARY_PATH`);
-    const haxe = new HaxeAsset(version, nightly);
     const haxePath = await haxe.setup();
     lib_core.addPath(haxePath);
     lib_core.exportVariable('HAXE_STD_PATH', external_node_path_namespaceObject.join(haxePath, 'std'));
-    if (env.platform === 'osx') {
+    if (external_node_os_.platform() === 'darwin') {
         lib_core.exportVariable('DYLD_FALLBACK_LIBRARY_PATH', `${nekoPath}:$DYLD_FALLBACK_LIBRARY_PATH`);
         // Ref: https://github.com/asdf-community/asdf-haxe/pull/7
         await (0,exec.exec)('ln', ['-sfv', external_node_path_namespaceObject.join(nekoPath, 'libneko.2.dylib'), external_node_path_namespaceObject.join(haxePath, 'libneko.2.dylib')]);
@@ -410,7 +461,7 @@ async function setup(version, nightly, cacheDependencyPath) {
     const haxelibPath = external_node_path_namespaceObject.join(haxePath, 'lib');
     await (0,exec.exec)('haxelib', ['setup', haxelibPath]);
     if (cacheDependencyPath.length > 0) {
-        const key = await createHaxelibKey(haxe.target, version, cacheDependencyPath);
+        const key = await createHaxelibKey(haxeCachePlatform, version, cacheDependencyPath);
         await restoreHaxelib(key, haxelibPath);
     }
 }

--- a/src/asset.test.ts
+++ b/src/asset.test.ts
@@ -1,7 +1,7 @@
 import type * as OsType from 'node:os';
 import * as os from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Env, HaxeAsset, NekoAsset } from './asset';
+import { HaxeAsset, NekoAsset, resolveTarget } from './asset';
 
 vi.mock('node:os', async () => {
   const actual = await vi.importActual<typeof OsType>('node:os');
@@ -15,13 +15,6 @@ vi.mock('node:os', async () => {
 function setOs(platform: string, arch: string): void {
   vi.mocked(os.platform).mockReturnValue(platform as NodeJS.Platform);
   vi.mocked(os.arch).mockReturnValue(arch);
-}
-
-function makeEnv(platform: 'linux' | 'osx' | 'win', arch: '64' | 'arm64'): Env {
-  const env = Object.create(Env.prototype) as Env;
-  Object.defineProperty(env, 'platform', { get: () => platform, configurable: true });
-  Object.defineProperty(env, 'arch', { get: () => arch, configurable: true });
-  return env;
 }
 
 class TestableHaxe extends HaxeAsset {
@@ -52,115 +45,109 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe('Env', () => {
-  it.each([
-    ['linux', 'x64', 'linux', '64'],
-    ['linux', 'arm64', 'linux', 'arm64'],
-    ['darwin', 'x64', 'osx', '64'],
-    ['darwin', 'arm64', 'osx', '64'],
-    ['win32', 'x64', 'win', '64'],
-    ['win32', 'arm64', 'win', 'arm64'],
-  ])('%s/%s -> platform=%s, arch=%s', (osPlatform, osArch, platform, arch) => {
-    setOs(osPlatform, osArch);
-    const env = new Env();
-    expect(env.platform).toBe(platform);
-    expect(env.arch).toBe(arch);
-  });
-
-  it('throws on unsupported platform', () => {
-    setOs('aix', 'x64');
-    const env = new Env();
-    expect(() => env.platform).toThrow(/aix not supported/);
-  });
-
-  it('throws on unsupported arch (ia32)', () => {
-    setOs('linux', 'ia32');
-    const env = new Env();
-    expect(() => env.arch).toThrow(/ia32 not supported/);
-  });
-});
-
 describe('HaxeAsset (stable)', () => {
   it.each([
-    ['linux', '64', '4.3.7', 'haxe-4.3.7-linux64.tar.gz', 'haxe-4.3.7-linux64'],
-    ['osx', '64', '4.3.7', 'haxe-4.3.7-osx.tar.gz', 'haxe-4.3.7-osx'],
-    ['osx', 'arm64', '4.3.7', 'haxe-4.3.7-osx.tar.gz', 'haxe-4.3.7-osx'],
-    ['win', '64', '4.3.7', 'haxe-4.3.7-win64.zip', 'haxe-4.3.7-win64'],
-    ['win', '64', '3.4.7', 'haxe-3.4.7-win.zip', 'haxe-3.4.7-win'],
+    ['linux', 'x64', '4.3.7', 'haxe-4.3.7-linux64.tar.gz', 'haxe-4.3.7-linux64'],
+    ['darwin', 'x64', '4.3.7', 'haxe-4.3.7-osx.tar.gz', 'haxe-4.3.7-osx'],
+    ['darwin', 'arm64', '4.3.7', 'haxe-4.3.7-osx.tar.gz', 'haxe-4.3.7-osx'],
+    ['win32', 'x64', '4.3.7', 'haxe-4.3.7-win64.zip', 'haxe-4.3.7-win64'],
+    ['win32', 'x64', '3.4.7', 'haxe-3.4.7-win.zip', 'haxe-3.4.7-win'],
   ] as const)('%s/%s + %s', (platform, arch, version, fileName, basename) => {
-    const env = makeEnv(platform, arch);
-    const asset = new TestableHaxe(version, false, env);
+    setOs(platform, arch);
+    const asset = new TestableHaxe(version, false);
     expect(asset.downloadUrl).toBe(`https://github.com/HaxeFoundation/haxe/releases/download/${version}/${fileName}`);
     expect(asset.fileNameWithoutExt).toBe(basename);
   });
 
-  it('Linux ARM64 + 4.3.7 currently falls through to linuxarm64 (unsupported upstream; pinned)', () => {
-    const env = makeEnv('linux', 'arm64');
-    const asset = new TestableHaxe('4.3.7', false, env);
-    expect(asset.downloadUrl).toBe(
-      'https://github.com/HaxeFoundation/haxe/releases/download/4.3.7/haxe-4.3.7-linuxarm64.tar.gz',
-    );
-    expect(asset.fileNameWithoutExt).toBe('haxe-4.3.7-linuxarm64');
+  it('Linux ARM64 + 4.3.7 throws an explicit unsupported error', () => {
+    setOs('linux', 'arm64');
+    const asset = new TestableHaxe('4.3.7', false);
+    expect(() => asset.downloadUrl).toThrow(/Stable Haxe does not publish Linux ARM64/);
+  });
+
+  it('Windows ARM64 + 4.3.7 throws an explicit unsupported error', () => {
+    setOs('win32', 'arm64');
+    const asset = new TestableHaxe('4.3.7', false);
+    expect(() => asset.downloadUrl).toThrow(/Windows ARM64 is not supported/);
   });
 });
 
 describe('HaxeAsset (nightly)', () => {
   it.each([
-    ['linux', '64', 'linux64'],
+    ['linux', 'x64', 'linux64'],
     ['linux', 'arm64', 'linux-arm64'],
-    ['osx', '64', 'mac'],
-    ['osx', 'arm64', 'mac'],
-    ['win', '64', 'windows64'],
+    ['darwin', 'x64', 'mac'],
+    ['darwin', 'arm64', 'mac'],
+    ['win32', 'x64', 'windows64'],
   ] as const)('%s/%s -> build.haxe.org/builds/haxe/%s', (platform, arch, segment) => {
-    const env = makeEnv(platform, arch);
-    const asset = new TestableHaxe('latest', true, env);
-    const ext = platform === 'win' ? 'zip' : 'tar.gz';
+    setOs(platform, arch);
+    const asset = new TestableHaxe('latest', true);
+    const ext = platform === 'win32' ? 'zip' : 'tar.gz';
     expect(asset.downloadUrl).toBe(`https://build.haxe.org/builds/haxe/${segment}/haxe_latest.${ext}`);
     expect(asset.fileNameWithoutExt).toBe('haxe_latest');
+  });
+
+  it('Windows ARM64 nightly throws an explicit unsupported error', () => {
+    setOs('win32', 'arm64');
+    const asset = new TestableHaxe('latest', true);
+    expect(() => asset.downloadUrl).toThrow(/Windows ARM64 is not supported/);
   });
 });
 
 describe('NekoAsset (stable)', () => {
   it.each([
-    ['linux', '64', '2.4.0', false, 'neko-2.4.0-linux64.tar.gz', 'v2-4-0'],
-    ['linux', '64', '2.3.0', false, 'neko-2.3.0-linux64.tar.gz', 'v2-3-0'],
+    ['linux', 'x64', '2.4.0', false, 'neko-2.4.0-linux64.tar.gz', 'v2-4-0'],
+    ['linux', 'x64', '2.3.0', false, 'neko-2.3.0-linux64.tar.gz', 'v2-3-0'],
     ['linux', 'arm64', '2.4.0', false, 'neko-2.4.0-linux-arm64.tar.gz', 'v2-4-0'],
-    ['osx', '64', '2.4.0', false, 'neko-2.4.0-osx-universal.tar.gz', 'v2-4-0'],
-    ['osx', 'arm64', '2.4.0', false, 'neko-2.4.0-osx-universal.tar.gz', 'v2-4-0'],
-    ['osx', '64', '2.3.0', false, 'neko-2.3.0-osx64.tar.gz', 'v2-3-0'],
-    ['win', '64', '2.4.0', false, 'neko-2.4.0-win64.zip', 'v2-4-0'],
-    ['win', '64', '2.3.0', true, 'neko-2.3.0-win.zip', 'v2-3-0'],
+    ['darwin', 'x64', '2.4.0', false, 'neko-2.4.0-osx-universal.tar.gz', 'v2-4-0'],
+    ['darwin', 'arm64', '2.4.0', false, 'neko-2.4.0-osx-universal.tar.gz', 'v2-4-0'],
+    ['darwin', 'x64', '2.3.0', false, 'neko-2.3.0-osx64.tar.gz', 'v2-3-0'],
+    ['win32', 'x64', '2.4.0', false, 'neko-2.4.0-win64.zip', 'v2-4-0'],
+    ['win32', 'x64', '2.3.0', true, 'neko-2.3.0-win.zip', 'v2-3-0'],
   ] as const)('%s/%s + Neko %s (force32=%s)', (platform, arch, version, force32, fileName, tag) => {
-    const env = makeEnv(platform, arch);
-    const asset = new TestableNeko(version, false, force32, env);
+    setOs(platform, arch);
+    const asset = new TestableNeko(version, false, force32);
     expect(asset.downloadUrl).toBe(`https://github.com/HaxeFoundation/neko/releases/download/${tag}/${fileName}`);
     expect(asset.fileNameWithoutExt).toBe(fileName.replace(/\.(?:tar\.gz|zip)$/, ''));
   });
+
+  it('Linux ARM64 + Neko 2.3.0 throws an explicit unsupported error', () => {
+    setOs('linux', 'arm64');
+    const asset = new TestableNeko('2.3.0', false, false);
+    expect(() => asset.downloadUrl).toThrow(/Neko 2\.3\.x has no Linux ARM64 binary/);
+  });
+
+  it('Windows ARM64 + Neko 2.4.0 throws an explicit unsupported error', () => {
+    setOs('win32', 'arm64');
+    const asset = new TestableNeko('2.4.0', false, false);
+    expect(() => asset.downloadUrl).toThrow(/Windows ARM64 is not supported/);
+  });
 });
 
-describe('NekoAsset (nightly; Linux ARM64 currently downloads linux64 — pinned bug)', () => {
+describe('NekoAsset (nightly)', () => {
   it.each([
-    ['linux', '64', 'linux64'],
-    ['linux', 'arm64', 'linux64'],
-    ['osx', '64', 'mac-universal'],
-    ['osx', 'arm64', 'mac-universal'],
-    ['win', '64', 'windows64'],
+    ['linux', 'x64', 'linux64'],
+    ['linux', 'arm64', 'linux-arm64'],
+    ['darwin', 'x64', 'mac-universal'],
+    ['darwin', 'arm64', 'mac-universal'],
+    ['win32', 'x64', 'windows64'],
   ] as const)('%s/%s -> build.haxe.org/builds/neko/%s', (platform, arch, segment) => {
-    const env = makeEnv(platform, arch);
-    const asset = new TestableNeko('latest', true, false, env);
-    const ext = platform === 'win' ? 'zip' : 'tar.gz';
+    setOs(platform, arch);
+    const asset = new TestableNeko('latest', true, false);
+    const ext = platform === 'win32' ? 'zip' : 'tar.gz';
     expect(asset.downloadUrl).toBe(`https://build.haxe.org/builds/neko/${segment}/neko_latest.${ext}`);
   });
 
   it.each([
-    ['linux', '64', 'neko-latest-linux64'],
-    ['linux', 'arm64', 'neko-latest-linux-arm64'],
-    ['osx', '64', 'neko-latest-osx64'],
-    ['win', '64', 'neko-latest-win64'],
-  ] as const)('%s/%s -> extract dir name = %s (current behavior; pinned for refactor)', (platform, arch, basename) => {
-    const env = makeEnv(platform, arch);
-    const asset = new TestableNeko('latest', true, false, env);
-    expect(asset.fileNameWithoutExt).toBe(basename);
+    ['linux', 'x64'],
+    ['linux', 'arm64'],
+    ['darwin', 'x64'],
+    ['darwin', 'arm64'],
+    ['win32', 'x64'],
+  ] as const)('%s/%s extract dir name = neko_latest (symmetric with HaxeAsset)', (platform, arch) => {
+    setOs(platform, arch);
+    const asset = new TestableNeko('latest', true, false);
+    expect(asset.fileNameWithoutExt).toBe('neko_latest');
   });
 });
 
@@ -195,15 +182,63 @@ describe('NekoAsset.resolveFromHaxeVersion', () => {
   });
 
   it.each([
-    ['3.4.7', '2.3.0'],
-    ['4.2.5', '2.3.0'],
-    ['4.3.0', '2.4.0'],
-  ] as const)('Linux ARM64 + Haxe %s -> Neko %s (currently downloads even when 2.3.x has no arm64 asset; pinned for refactor)', (haxeVer, expectedNeko) => {
+    ['3.4.7'],
+    ['4.2.5'],
+  ] as const)('Linux ARM64 + Haxe %s (Neko 2.3.0) -> downloadUrl throws unsupported', (haxeVer) => {
     setOs('linux', 'arm64');
     const neko = NekoAsset.resolveFromHaxeVersion(haxeVer, false);
-    expect(neko.version).toBe(expectedNeko);
-    expect((neko as unknown as { force32: boolean }).force32).toBe(false);
-    const asset = new TestableNeko(neko.version, false, false, makeEnv('linux', 'arm64'));
-    expect(asset.fileNameWithoutExt).toBe(`neko-${expectedNeko}-linux-arm64`);
+    expect(neko.version).toBe('2.3.0');
+    expect(() => (neko as unknown as { downloadUrl: string }).downloadUrl).toThrow(/Neko 2\.3\.x has no Linux ARM64/);
+  });
+
+  it('Linux ARM64 + Haxe 4.3.0 (Neko 2.4.0) -> linux-arm64 archive', () => {
+    setOs('linux', 'arm64');
+    const neko = NekoAsset.resolveFromHaxeVersion('4.3.0', false);
+    expect(neko.version).toBe('2.4.0');
+    expect((neko as unknown as { fileNameWithoutExt: string }).fileNameWithoutExt).toBe('neko-2.4.0-linux-arm64');
+  });
+});
+
+describe('resolveTarget cachePlatform (haxelib cache key compatibility)', () => {
+  it.each([
+    ['haxe', '4.3.7', 'linux', 'x64', false, 'linux64'],
+    ['haxe', '4.3.7', 'darwin', 'x64', false, 'osx'],
+    ['haxe', '4.3.7', 'darwin', 'arm64', false, 'osx'],
+    ['haxe', '4.3.7', 'win32', 'x64', false, 'win64'],
+    ['haxe', '3.4.7', 'win32', 'x64', false, 'win'],
+    ['haxe', 'latest', 'linux', 'x64', true, 'linux64'],
+    ['haxe', 'latest', 'darwin', 'arm64', true, 'osx'],
+    ['haxe', 'latest', 'linux', 'arm64', true, 'linux-arm64'],
+    ['neko', '2.4.0', 'linux', 'x64', false, 'linux64'],
+    ['neko', '2.4.0', 'darwin', 'arm64', false, 'osx'],
+    ['neko', '2.4.0', 'linux', 'arm64', false, 'linux-arm64'],
+  ] as const)('%s %s on %s/%s (nightly=%s) -> cachePlatform=%s', (tool, version, platform, arch, nightly, expectedCachePlatform) => {
+    const result = resolveTarget({
+      tool,
+      version,
+      platform: platform as NodeJS.Platform,
+      arch,
+      nightly,
+      force32: false,
+    });
+    expect(result.kind).not.toBe('unsupported');
+    if (result.kind !== 'unsupported') {
+      expect(result.cachePlatform).toBe(expectedCachePlatform);
+    }
+  });
+
+  it('Neko 2.3.0 on Windows with force32 -> cachePlatform=win', () => {
+    const result = resolveTarget({
+      tool: 'neko',
+      version: '2.3.0',
+      platform: 'win32',
+      arch: 'x64',
+      nightly: false,
+      force32: true,
+    });
+    expect(result.kind).toBe('stable');
+    if (result.kind === 'stable') {
+      expect(result.cachePlatform).toBe('win');
+    }
   });
 });

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -13,11 +13,11 @@ import * as core from '@actions/core';
 import { exec } from '@actions/exec';
 import * as tc from '@actions/tool-cache';
 
-export type AssetFileExt = '.zip' | '.tar.gz';
+type AssetFileExt = '.zip' | '.tar.gz';
 
 type Tool = 'haxe' | 'neko';
 
-export type Resolution =
+type Resolution =
   | { kind: 'stable'; cachePlatform: string; archiveTarget: string }
   | { kind: 'nightly'; cachePlatform: string; nightlyPathSegment: string }
   | { kind: 'unsupported'; reason: string };

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -15,11 +15,168 @@ import * as tc from '@actions/tool-cache';
 
 export type AssetFileExt = '.zip' | '.tar.gz';
 
+type Tool = 'haxe' | 'neko';
+
+export type Resolution =
+  | { kind: 'stable'; cachePlatform: string; archiveTarget: string }
+  | { kind: 'nightly'; cachePlatform: string; nightlyPathSegment: string }
+  | { kind: 'unsupported'; reason: string };
+
+type SupportedResolution = Extract<Resolution, { kind: 'stable' | 'nightly' }>;
+
+interface ResolveInput {
+  tool: Tool;
+  version: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  nightly: boolean;
+  force32: boolean;
+}
+
+export function resolveTarget(input: ResolveInput): Resolution {
+  const { tool, platform, arch } = input;
+
+  if (platform === 'win32' && arch === 'arm64') {
+    return {
+      kind: 'unsupported',
+      reason: 'Windows ARM64 is not supported (no upstream Haxe/Neko archives).',
+    };
+  }
+
+  if (platform !== 'darwin' && platform !== 'linux' && platform !== 'win32') {
+    return { kind: 'unsupported', reason: `${platform} is not supported.` };
+  }
+
+  if (arch !== 'x64' && arch !== 'arm64') {
+    return { kind: 'unsupported', reason: `${arch} is not supported.` };
+  }
+
+  return tool === 'haxe'
+    ? resolveHaxe({ version: input.version, platform, arch, nightly: input.nightly })
+    : resolveNeko({
+        version: input.version,
+        platform,
+        arch,
+        nightly: input.nightly,
+        force32: input.force32,
+      });
+}
+
+function resolveHaxe(input: {
+  version: string;
+  platform: 'darwin' | 'linux' | 'win32';
+  arch: 'x64' | 'arm64';
+  nightly: boolean;
+}): Resolution {
+  const { version, platform, arch, nightly } = input;
+
+  if (nightly) {
+    switch (platform) {
+      case 'darwin': {
+        return { kind: 'nightly', cachePlatform: 'osx', nightlyPathSegment: 'mac' };
+      }
+
+      case 'linux': {
+        return arch === 'arm64'
+          ? { kind: 'nightly', cachePlatform: 'linux-arm64', nightlyPathSegment: 'linux-arm64' }
+          : { kind: 'nightly', cachePlatform: 'linux64', nightlyPathSegment: 'linux64' };
+      }
+
+      case 'win32': {
+        return { kind: 'nightly', cachePlatform: 'win64', nightlyPathSegment: 'windows64' };
+      }
+    }
+  }
+
+  switch (platform) {
+    case 'darwin': {
+      return { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx' };
+    }
+
+    case 'linux': {
+      if (arch === 'arm64') {
+        return {
+          kind: 'unsupported',
+          reason: "Stable Haxe does not publish Linux ARM64 archives upstream; use 'haxe-version: latest'.",
+        };
+      }
+
+      return { kind: 'stable', cachePlatform: 'linux64', archiveTarget: 'linux64' };
+    }
+
+    case 'win32': {
+      if (version.startsWith('3.')) {
+        return { kind: 'stable', cachePlatform: 'win', archiveTarget: 'win' };
+      }
+
+      return { kind: 'stable', cachePlatform: 'win64', archiveTarget: 'win64' };
+    }
+  }
+}
+
+function resolveNeko(input: {
+  version: string;
+  platform: 'darwin' | 'linux' | 'win32';
+  arch: 'x64' | 'arm64';
+  nightly: boolean;
+  force32: boolean;
+}): Resolution {
+  const { version, platform, arch, nightly, force32 } = input;
+
+  if (nightly) {
+    switch (platform) {
+      case 'darwin': {
+        return { kind: 'nightly', cachePlatform: 'osx', nightlyPathSegment: 'mac-universal' };
+      }
+
+      case 'linux': {
+        return arch === 'arm64'
+          ? { kind: 'nightly', cachePlatform: 'linux-arm64', nightlyPathSegment: 'linux-arm64' }
+          : { kind: 'nightly', cachePlatform: 'linux64', nightlyPathSegment: 'linux64' };
+      }
+
+      case 'win32': {
+        return { kind: 'nightly', cachePlatform: 'win64', nightlyPathSegment: 'windows64' };
+      }
+    }
+  }
+
+  switch (platform) {
+    case 'darwin': {
+      return version.startsWith('2.4')
+        ? { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx-universal' }
+        : { kind: 'stable', cachePlatform: 'osx', archiveTarget: 'osx64' };
+    }
+
+    case 'linux': {
+      if (arch === 'arm64') {
+        if (version.startsWith('2.3')) {
+          return {
+            kind: 'unsupported',
+            reason: "Neko 2.3.x has no Linux ARM64 binary; requires Neko 2.4+ (use Haxe 4.3+ or 'latest').",
+          };
+        }
+
+        return { kind: 'stable', cachePlatform: 'linux-arm64', archiveTarget: 'linux-arm64' };
+      }
+
+      return { kind: 'stable', cachePlatform: 'linux64', archiveTarget: 'linux64' };
+    }
+
+    case 'win32': {
+      if (force32) {
+        return { kind: 'stable', cachePlatform: 'win', archiveTarget: 'win' };
+      }
+
+      return { kind: 'stable', cachePlatform: 'win64', archiveTarget: 'win64' };
+    }
+  }
+}
+
 abstract class Asset {
   constructor(
     readonly name: string,
     readonly version: string,
-    protected readonly env: Env,
   ) {}
 
   async setup() {
@@ -31,6 +188,8 @@ abstract class Asset {
     return tc.cacheDir(await this.download(), this.name, this.version);
   }
 
+  abstract get cachePlatform(): string;
+
   protected abstract get downloadUrl(): string;
   protected abstract get fileNameWithoutExt(): string;
   protected abstract get isDirectoryNested(): boolean;
@@ -40,15 +199,30 @@ abstract class Asset {
   }
 
   protected get fileExt(): AssetFileExt {
-    switch (this.env.platform) {
-      case 'win': {
-        return '.zip';
-      }
+    return os.platform() === 'win32' ? '.zip' : '.tar.gz';
+  }
 
-      default: {
-        return '.tar.gz';
-      }
+  protected resolve(tool: Tool, force32 = false): Resolution {
+    return resolveTarget({
+      tool,
+      version: this.version,
+      platform: os.platform(),
+      arch: os.arch(),
+      nightly: this.isNightly,
+      force32,
+    });
+  }
+
+  protected get isNightly(): boolean {
+    return false;
+  }
+
+  protected requireSupported(resolution: Resolution): SupportedResolution {
+    if (resolution.kind === 'unsupported') {
+      throw new Error(resolution.reason);
     }
+
+    return resolution;
   }
 
   private async download() {
@@ -144,18 +318,16 @@ abstract class Asset {
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 export class NekoAsset extends Asset {
   static resolveFromHaxeVersion(version: string, nightly: boolean) {
-    const env = new Env();
-
     if (nightly) {
-      return new NekoAsset('latest', true, false, env);
+      return new NekoAsset('latest', true, false);
     }
 
     // Haxe older than 4.3 has issues with mbedtls 3 in neko 2.4
     const nekoVer = version.startsWith('3.') || (version.startsWith('4.') && version < '4.3.') ? '2.3.0' : '2.4.0';
     // Haxe 3 on windows has 32 bit haxelib, which requires 32 bit neko
-    const force32 = version.startsWith('3.') && env.platform === 'win';
+    const force32 = version.startsWith('3.') && os.platform() === 'win32';
 
-    return new NekoAsset(nekoVer, false, force32, env);
+    return new NekoAsset(nekoVer, false, force32);
   }
 
   nightly = false;
@@ -164,64 +336,40 @@ export class NekoAsset extends Asset {
     version: string,
     nightly: boolean,
     protected readonly force32: boolean,
-    env = new Env(),
   ) {
-    super('neko', version, env);
+    super('neko', version);
     this.nightly = nightly;
   }
 
+  get cachePlatform() {
+    return this.requireSupported(this.resolve('neko', this.force32)).cachePlatform;
+  }
+
   get downloadUrl() {
-    if (this.nightly) {
-      return `https://build.haxe.org/builds/neko/${this.nightlyTarget}/neko_${this.version}${this.fileExt}`;
+    const resolution = this.requireSupported(this.resolve('neko', this.force32));
+    if (resolution.kind === 'nightly') {
+      return `https://build.haxe.org/builds/neko/${resolution.nightlyPathSegment}/${this.fileNameWithoutExt}${this.fileExt}`;
     }
 
     const tag = `v${this.version.replace(/\./g, '-')}`;
     return super.makeDownloadUrl(`/neko/releases/download/${tag}/${this.fileNameWithoutExt}${this.fileExt}`);
   }
 
-  get target() {
-    if (this.force32) {
-      return this.env.platform;
-    }
-
-    if (this.env.platform === 'osx' && this.version.startsWith('2.4')) {
-      return 'osx-universal';
-    }
-
-    if (this.env.platform === 'linux' && this.env.arch === 'arm64') {
-      return 'linux-arm64';
-    }
-
-    return `${this.env.platform}${this.env.arch}`;
-  }
-
-  get nightlyTarget() {
-    const plat = this.env.platform;
-    switch (plat) {
-      case 'osx': {
-        return 'mac-universal';
-      }
-
-      case 'linux': {
-        return 'linux64';
-      }
-
-      case 'win': {
-        return 'windows64';
-      }
-
-      default: {
-        throw new Error(`${plat} not supported`);
-      }
-    }
-  }
-
   get fileNameWithoutExt() {
-    return `neko-${this.version}-${this.target}`;
+    const resolution = this.requireSupported(this.resolve('neko', this.force32));
+    if (resolution.kind === 'nightly') {
+      return `neko_${this.version}`;
+    }
+
+    return `neko-${this.version}-${resolution.archiveTarget}`;
   }
 
   get isDirectoryNested() {
     return true;
+  }
+
+  protected override get isNightly() {
+    return this.nightly;
   }
 }
 
@@ -231,99 +379,38 @@ export class NekoAsset extends Asset {
 export class HaxeAsset extends Asset {
   nightly = false;
 
-  constructor(version: string, nightly: boolean, env = new Env()) {
-    super('haxe', version, env);
+  constructor(version: string, nightly: boolean) {
+    super('haxe', version);
     this.nightly = nightly;
   }
 
+  get cachePlatform() {
+    return this.requireSupported(this.resolve('haxe')).cachePlatform;
+  }
+
   get downloadUrl() {
-    if (this.nightly) {
-      return `https://build.haxe.org/builds/haxe/${this.nightlyTarget}/${this.fileNameWithoutExt}${this.fileExt}`;
+    const resolution = this.requireSupported(this.resolve('haxe'));
+    if (resolution.kind === 'nightly') {
+      return `https://build.haxe.org/builds/haxe/${resolution.nightlyPathSegment}/${this.fileNameWithoutExt}${this.fileExt}`;
     }
 
     return super.makeDownloadUrl(`/haxe/releases/download/${this.version}/${this.fileNameWithoutExt}${this.fileExt}`);
   }
 
-  get target() {
-    if (this.env.platform === 'osx') {
-      return this.env.platform;
-    }
-
-    // No 64bit version of neko 2.1 available for windows, thus we can also only use 32bit version of Haxe 3
-    if (this.env.platform === 'win' && this.version.startsWith('3.')) {
-      return this.env.platform;
-    }
-
-    return `${this.env.platform}${this.env.arch}`;
-  }
-
-  get nightlyTarget() {
-    const plat = this.env.platform;
-    switch (plat) {
-      case 'osx': {
-        return 'mac';
-      }
-
-      case 'linux': {
-        return this.env.arch === 'arm64' ? 'linux-arm64' : 'linux64';
-      }
-
-      case 'win': {
-        return 'windows64';
-      }
-
-      default: {
-        throw new Error(`${plat} not supported`);
-      }
-    }
-  }
-
   get fileNameWithoutExt() {
-    if (this.nightly) {
+    const resolution = this.requireSupported(this.resolve('haxe'));
+    if (resolution.kind === 'nightly') {
       return `haxe_${this.version}`;
     }
 
-    return `haxe-${this.version}-${this.target}`;
+    return `haxe-${this.version}-${resolution.archiveTarget}`;
   }
 
   get isDirectoryNested() {
     return true;
   }
-}
 
-export class Env {
-  get platform() {
-    const plat = os.platform();
-    switch (plat) {
-      case 'linux': {
-        return 'linux';
-      }
-
-      case 'win32': {
-        return 'win';
-      }
-
-      case 'darwin': {
-        return 'osx';
-      }
-
-      default: {
-        throw new Error(`${plat} not supported`);
-      }
-    }
-  }
-
-  get arch() {
-    const arch = os.arch();
-
-    if (arch === 'x64') {
-      return '64';
-    }
-
-    if (arch === 'arm64') {
-      return this.platform === 'osx' ? '64' : 'arm64';
-    }
-
-    throw new Error(`${arch} not supported`);
+  protected override get isNightly() {
+    return this.nightly;
   }
 }

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { saveHaxelib } from './haxelib';
 
-export async function run() {
+async function run() {
   try {
     const cacheDependencyPath = core.getInput('cache-dependency-path');
     if (cacheDependencyPath.length > 0) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,27 +3,30 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';
-import { Env, HaxeAsset, NekoAsset } from './asset';
+import { HaxeAsset, NekoAsset } from './asset';
 import { createHaxelibKey, restoreHaxelib } from './haxelib';
 
-const env = new Env();
-
 export async function setup(version: string, nightly: boolean, cacheDependencyPath: string) {
+  const haxe = new HaxeAsset(version, nightly);
+  // Preflight: fail fast on unsupported combinations (e.g. stable Haxe + Linux ARM64)
+  // before downloading Neko. cachePlatform throws when the resolver returns 'unsupported'.
+  const haxeCachePlatform = haxe.cachePlatform;
+
   const neko = NekoAsset.resolveFromHaxeVersion(version, nightly); // Haxelib requires Neko
   const nekoPath = await neko.setup();
   core.addPath(nekoPath);
   core.exportVariable('NEKOPATH', nekoPath);
   core.exportVariable('LD_LIBRARY_PATH', `${nekoPath}:$LD_LIBRARY_PATH`);
 
-  const haxe = new HaxeAsset(version, nightly);
   const haxePath = await haxe.setup();
   core.addPath(haxePath);
   core.exportVariable('HAXE_STD_PATH', path.join(haxePath, 'std'));
 
-  if (env.platform === 'osx') {
+  if (os.platform() === 'darwin') {
     core.exportVariable('DYLD_FALLBACK_LIBRARY_PATH', `${nekoPath}:$DYLD_FALLBACK_LIBRARY_PATH`);
 
     // Ref: https://github.com/asdf-community/asdf-haxe/pull/7
@@ -34,7 +37,7 @@ export async function setup(version: string, nightly: boolean, cacheDependencyPa
   await exec('haxelib', ['setup', haxelibPath]);
 
   if (cacheDependencyPath.length > 0) {
-    const key = await createHaxelibKey(haxe.target, version, cacheDependencyPath);
+    const key = await createHaxelibKey(haxeCachePlatform, version, cacheDependencyPath);
     await restoreHaxelib(key, haxelibPath);
   }
 }


### PR DESCRIPTION
## Summary

Consolidate platform/arch/nightly archive selection into a single pure resolver. Replaces the previous logic spread across `Env`, `HaxeAsset.target`, `NekoAsset.target`, and `nightlyTarget` — which produced opaque curl 404s for unsupported combinations — with a discriminated-union resolver and explicit errors.

Closes the follow-up items from #71 and #68 (Stable Haxe + Linux ARM64, Haxe < 4.3 + Linux ARM64, Windows ARM64, the `linuxarm64` vs `linux-arm64` cache-key drift, and the `NekoAsset` nightly asymmetry).

## Changes

- `resolveTarget(...)` returns a `Resolution` union (`stable` / `nightly` / `unsupported`) and splits the overloaded `target` into three name spaces: `cachePlatform` (haxelib cache key), `archiveTarget` (GitHub release name), `nightlyPathSegment` (`build.haxe.org` path).
- `Env` removed; `os.platform()` / `os.arch()` raw values feed the resolver. `HaxeAsset` / `NekoAsset` become thin wrappers over the resolution.
- Unsupported combinations throw with explicit reasons: stable Haxe + Linux ARM64, Haxe < 4.3 + Linux ARM64, Windows ARM64.
- `NekoAsset` nightly: `fileNameWithoutExt` is now `neko_${version}` (symmetric with `HaxeAsset`, extract dir `neko_latest`); Linux ARM64 uses `linux-arm64` (was hard-coded `linux64`).
- `setup.ts` passes `haxe.cachePlatform` (not `haxe.target`) to `createHaxelibKey()`, breaking the cache-key/archive-name coupling. Existing keys (`linux64` / `osx` / `win64` / `win`) preserved. Unsupported combinations fail fast before any download.
- README: add "Supported combinations" table.
- Tests: flip the will-change assertions pinned in #89 to the new expected behavior; add direct `resolveTarget` cache-platform tests.
- Drop unused `export` on `AssetFileExt` / `Resolution` / `run`.
- Regenerate `dist/`.

## Out of scope

- Semver migration of the `version < '4.3.'` string comparison.
- `v2` release tag bump (follows this PR).

## Test plan

- [x] `npm test` passes locally (biome + 61 vitest tests).
- [x] `npm run dist` regenerated; diff matches `src/` intent.
- [x] CI matrix green on Linux x64 / macOS / Windows × `3.4.7` / `4.3.7` / `latest`.
- [x] `build (latest, ubuntu-24.04-arm)` green (the original failing job from #71).
