### PR TITLE
chore(ci): tighten test workflow and harden supply chain

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,11 +41,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
 
     - run: npm ci
     - run: npm run test
+    - run: npm run dist
+    - name: Verify committed dist is up to date
+      run: git diff --exit-code -- dist
 
   build:
     needs: lint-and-unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,17 @@ name: CI
 
 on:
   push:
-    branches:    # build all branches
-    - '**'
-    tags-ignore: # but don't build tags
-    - '**'
+    branches:
+    - master
     paths-ignore:
     # NOTE: '.github/*.yml' matches only files directly under .github/ (e.g. dependabot.yml).
     # Workflow files under .github/workflows/ intentionally trigger CI when edited.
     - '**/*.md'
     - '.github/*.yml'
   pull_request:
+    paths-ignore:
+    - '**/*.md'
+    - '.github/*.yml'
   workflow_dispatch:
     # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 name: CI
 
 on:
@@ -6,16 +5,15 @@ on:
     branches:
     - master
     paths-ignore:
+    - '**/*.md'
     # NOTE: '.github/*.yml' matches only files directly under .github/ (e.g. dependabot.yml).
     # Workflow files under .github/workflows/ intentionally trigger CI when edited.
-    - '**/*.md'
     - '.github/*.yml'
   pull_request:
     paths-ignore:
     - '**/*.md'
     - '.github/*.yml'
   workflow_dispatch:
-    # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,16 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
     paths-ignore:
-    - '**/*.md'
-    # NOTE: '.github/*.yml' matches only files directly under .github/ (e.g. dependabot.yml).
-    # Workflow files under .github/workflows/ intentionally trigger CI when edited.
-    - '.github/*.yml'
+      - "**/*.md"
+      # NOTE: '.github/*.yml' matches only files directly under .github/ (e.g. dependabot.yml).
+      # Workflow files under .github/workflows/ intentionally trigger CI when edited.
+      - ".github/*.yml"
   pull_request:
     paths-ignore:
-    - '**/*.md'
-    - '.github/*.yml'
+      - "**/*.md"
+      - ".github/*.yml"
   workflow_dispatch:
 
 permissions:
@@ -30,21 +30,23 @@ jobs:
   lint-and-unit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
     steps:
-    - name: Git Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Git Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: .node-version
-        cache: npm
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .node-version
+          cache: npm
 
-    - run: npm ci
-    - run: npm run test
-    - run: npm run dist
-    - name: Verify committed dist is up to date
-      run: git diff --exit-code -- dist
+      - run: npm ci
+      - run: npm run test
+      - run: npm run dist
+
+      - name: Verify committed dist is up to date
+        run: git diff --exit-code -- dist
 
   build:
     needs: lint-and-unit
@@ -55,47 +57,46 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
         haxe:
-        - latest
-        - 4.3.7
-        - 3.4.7
+          - latest
+          - 4.3.7
+          - 3.4.7
         include:
-        - haxe: 3.4.7
-          hxml_suffix: _haxe3
-        - haxe: latest
-          os: ubuntu-24.04-arm
+          - haxe: 3.4.7
+            hxml_suffix: _haxe3
+          - haxe: latest
+            os: ubuntu-24.04-arm
 
     env:
       TEST_LIB_HXML: test-workflow/lib${{ matrix.hxml_suffix }}.hxml
 
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Git Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Haxe ${{ matrix.haxe }}
+        uses: ./
+        with:
+          haxe-version: ${{ matrix.haxe }}
 
-    - name: Install Haxe ${{ matrix.haxe }}
-      uses: ./
-      with:
-        haxe-version: ${{ matrix.haxe }}
+      - name: Re-install Haxe ${{ matrix.haxe }} (idempotency check)
+        uses: ./
+        with:
+          haxe-version: ${{ matrix.haxe }}
+          cache-dependency-path: ${{ env.TEST_LIB_HXML }}
 
-    - name: Re-install Haxe ${{ matrix.haxe }} (idempotency check)
-      uses: ./
-      with:
-        haxe-version: ${{ matrix.haxe }}
-        cache-dependency-path: ${{ env.TEST_LIB_HXML }}
+      - run: neko -version
+      - run: haxe -version
 
-    - run: neko -version
-    - run: haxe -version
+      - run: haxelib install ${{ env.TEST_LIB_HXML }} --always
 
-    - run: haxelib install ${{ env.TEST_LIB_HXML }} --always
-
-    - name: Compile test code
-      run: |
-        haxe \
-          -cp test-workflow \
-          -lib hxnodejs \
-          -main Main \
-          -js test-workflow.js
+      - name: Compile test code
+        run: |
+          haxe \
+            -cp test-workflow \
+            -lib hxnodejs \
+            -main Main \
+            -js test-workflow.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,46 @@ on:
     tags-ignore: # but don't build tags
     - '**'
     paths-ignore:
+    # NOTE: '.github/*.yml' matches only files directly under .github/ (e.g. dependabot.yml).
+    # Workflow files under .github/workflows/ intentionally trigger CI when edited.
     - '**/*.md'
     - '.github/*.yml'
   pull_request:
   workflow_dispatch:
     # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
 
 jobs:
+  lint-and-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .node-version
+        cache: npm
+
+    - run: npm ci
+    - run: npm run test
+
   build:
+    needs: lint-and-unit
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -47,22 +74,12 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v6 #https://github.com/actions/checkout
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: .node-version
-
-    - run: |
-        npm ci
-        npm run test
-
     - name: Install Haxe ${{ matrix.haxe }}
       uses: ./
       with:
         haxe-version: ${{ matrix.haxe }}
 
-    # install twice to verify re-installation works
-    - name: Install Haxe ${{ matrix.haxe }}
+    - name: Re-install Haxe ${{ matrix.haxe }} (idempotency check)
       uses: ./
       with:
         haxe-version: ${{ matrix.haxe }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: .node-version
         cache: npm
@@ -72,7 +72,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6 #https://github.com/actions/checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Haxe ${{ matrix.haxe }}
       uses: ./


### PR DESCRIPTION
## Summary

Tighten `.github/workflows/test.yml` against best practices. No runtime behavior change for the action itself.

- Split lint + unit into a dedicated `lint-and-unit` job; the build matrix `needs:` it, eliminating 9× redundant `npm ci && npm run test`.
- Add `permissions: contents: read`, `concurrency`, `timeout-minutes`, and `cache: npm`.
- Pin all third-party actions (test.yml + codeql-analysis.yml) to commit SHAs. The existing `.github/dependabot.yml` keeps them current.
- Add a `dist/` sync check so a missed `npm run dist` fails CI.
- Scope triggers to master pushes / PRs only and mirror `paths-ignore` on `pull_request`. Removes the push + pull_request double-fire on PR sync. Fork contributors can use draft PRs or `workflow_dispatch`.
- Drop reference-link comments and reformat for consistency.

## Test plan

- [x] All workflow cells green on this branch (lint-and-unit + 9 build matrix cells).
- [x] `dist/` sync check passes against the currently committed `dist/`.
- [ ] Confirm trigger scope by inspecting the run list (master push / PR open / sync).
