### PR TITLE
refactor(asset): unify subclass fields via parameter properties

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -301,6 +301,7 @@ class Asset {
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-osx-universal.tar.gz
 // * NOTE https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-win64.zip
 class NekoAsset extends Asset {
+    nightly;
     force32;
     static resolveFromHaxeVersion(version, nightly) {
         if (nightly) {
@@ -312,11 +313,10 @@ class NekoAsset extends Asset {
         const force32 = version.startsWith('3.') && external_node_os_.platform() === 'win32';
         return new NekoAsset(nekoVer, false, force32);
     }
-    nightly = false;
     constructor(version, nightly, force32) {
         super('neko', version);
-        this.force32 = force32;
         this.nightly = nightly;
+        this.force32 = force32;
     }
     get cachePlatform() {
         return this.requireSupported(this.resolve('neko', this.force32)).cachePlatform;
@@ -347,7 +347,7 @@ class NekoAsset extends Asset {
 // * NOTE https://github.com/HaxeFoundation/haxe/releases/download/3.4.7/haxe-3.4.7-win64.zip
 // * NOTE https://build.haxe.org/builds/haxe/mac/haxe_latest.tar.gz
 class HaxeAsset extends Asset {
-    nightly = false;
+    nightly;
     constructor(version, nightly) {
         super('haxe', version);
         this.nightly = nightly;

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -330,15 +330,12 @@ export class NekoAsset extends Asset {
     return new NekoAsset(nekoVer, false, force32);
   }
 
-  nightly = false;
-
   constructor(
     version: string,
-    nightly: boolean,
+    protected readonly nightly: boolean,
     protected readonly force32: boolean,
   ) {
     super('neko', version);
-    this.nightly = nightly;
   }
 
   get cachePlatform() {
@@ -377,11 +374,11 @@ export class NekoAsset extends Asset {
 // * NOTE https://github.com/HaxeFoundation/haxe/releases/download/3.4.7/haxe-3.4.7-win64.zip
 // * NOTE https://build.haxe.org/builds/haxe/mac/haxe_latest.tar.gz
 export class HaxeAsset extends Asset {
-  nightly = false;
-
-  constructor(version: string, nightly: boolean) {
+  constructor(
+    version: string,
+    protected readonly nightly: boolean,
+  ) {
     super('haxe', version);
-    this.nightly = nightly;
   }
 
   get cachePlatform() {


### PR DESCRIPTION
## Summary

Unify how `HaxeAsset` and `NekoAsset` declare their constructor-derived fields. The `nightly` field, previously declared as `nightly = false;` and assigned in the constructor body, is now a `protected readonly` parameter property — matching the existing `force32` style on `NekoAsset`. No behavior change.

- Drops the redundant default initializer and `this.nightly = nightly` assignment.
- Tightens visibility from implicit `public` to `protected readonly` (no external readers exist).
- Regenerates `dist/index.js` to keep the bundle in sync (CI enforces this).

## Test plan

- [x] `npm run build` (tsc) passes
- [x] `npm test` passes (58/58 in `asset.test.ts`)
- [x] `dist/` sync check passes (re-bundled via `npm run dist`)
