### PR TITLE
docs(README): bump `actions/checkout` from v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: 4.3.7
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: latest  # Install 'haxe_latest.tar.gz' from https://build.haxe.org/builds/haxe/linux64/
@@ -58,7 +58,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: 4.3.7


### PR DESCRIPTION
This ensures anyone to use the minimum version of `actions/checkout` that uses Node 24 to avoid minor confusions.